### PR TITLE
Fix initialization of TStaticArray

### DIFF
--- a/include/cppcore/Container/TStaticArray.h
+++ b/include/cppcore/Container/TStaticArray.h
@@ -39,11 +39,12 @@ template<class T, size_t len>
 class TStaticArray {
 public:
     TStaticArray();
+    TStaticArray(T initValue);
     TStaticArray(const TStaticArray<T, len> &rhs);
     ~TStaticArray();
-    void clear();
     size_t size() const;
     void set(size_t index, T value);
+    void memset(T value);
     T operator[](size_t index) const;
     T &operator[](size_t index);
     bool operator == (const TStaticArray<T, len> &rhs) const;
@@ -51,21 +52,28 @@ public:
 
 private:
     T m_array[len];
-	size_t m_len;
+    size_t m_len;
 };
 
-template <class T, size_t len>
+template<class T, size_t len>
 inline
 TStaticArray<T,len>::TStaticArray() 
 : m_len(len) {
-    clear();
+    // empty
+}
+
+template<class T, size_t len>
+inline
+TStaticArray<T, len>::TStaticArray( T initValue ) :
+        m_len(len) {
+    memset(initValue);
 }
 
 template <class T, size_t len>
 inline
 TStaticArray<T, len>::TStaticArray(const TStaticArray<T, len> &rhs)
 : m_len(rhs.m_len) {
-	for (size_t i = 0; i < m_len; ++i) {
+    for (size_t i = 0; i < m_len; ++i) {
         m_array[i] = rhs.m_array[i];
     }
 }
@@ -78,16 +86,18 @@ TStaticArray<T, len>::~TStaticArray() {
 
 template<class T, size_t len>
 inline
-void TStaticArray<T, len>::clear() {
-    ::memset(m_array, 0, sizeof(T) * m_len);
-}
-
-template<class T, size_t len>
-inline
 void TStaticArray<T, len>::set(size_t index, T value) {
     assert(index < m_len);
 
     m_array[index] = value;
+}
+
+template<class T, size_t len>
+inline
+void TStaticArray<T, len>::memset( T value ) {
+    for ( size_t i=0; i<m_len; ++i ) {
+        m_array[i] = value;
+    }
 }
 
 template<class T, size_t len>

--- a/test/container/TArrayTest.cpp
+++ b/test/container/TArrayTest.cpp
@@ -67,9 +67,14 @@ TEST_F( TArrayTest, constructTest ) {
 // Just checks how to initialize the array
 TEST_F( TArrayTest, constructWithSizeTest) {
     TArray<float> arrayInstance( 4 );
+    arrayInstance[0] = 0.0f;
+    arrayInstance[1] = 1.0f;
+    arrayInstance[2] = 2.0f;
+    arrayInstance[3] = 3.0f;
     EXPECT_EQ( 4u, arrayInstance.size() );
     for ( size_t i=0; i<4; ++i ) {
         const float f = arrayInstance[i];
+	EXPECT_EQ( (float) i, f );
     }
 }
 

--- a/test/container/TStaticArrayTest.cpp
+++ b/test/container/TStaticArrayTest.cpp
@@ -41,7 +41,7 @@ class TStaticArrayTest : public testing::Test {
 };
 
 TEST_F(TStaticArrayTest, constructTest) {
-    TStaticArray<int, 4> arr;
+    TStaticArray<int, 4> arr(0);
     EXPECT_EQ(4u, arr.size());
     EXPECT_EQ(0, arr[0]);
     EXPECT_EQ(0, arr[3]);
@@ -62,14 +62,14 @@ TEST_F(TStaticArrayTest, clear_Test) {
     for (size_t i = 0; i < 4; ++i) {
         arr[i] = i;
     }
-    arr.clear();
+    arr.memset( 0 );
     for (size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(0, arr[i]);
     }
 }
 
 TEST_F(TStaticArrayTest, access_string_Test) {
-    TStaticArray < std::string, 4> arr;
+    TStaticArray <std::string, 4> arr;
     arr[0] = std::string("bla");
     arr[1] = std::string("bla");
     arr[2] = std::string("bla");


### PR DESCRIPTION
- closes https://github.com/kimkulling/cppcore/issues/7
- Not use memset to init std::string in a static array type.